### PR TITLE
Fix command name to `gows version` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ go get -u github.com/bitrise-tools/gows
 ```
 
 That's all. If you have a "properly" configured Go environment (see the previous Install section)
-then you should be able to run `gows -version` now, and be able to run `gows` in any directory.
+then you should be able to run `gows version` now, and be able to run `gows` in any directory.
 
 
 ## Usage
@@ -135,7 +135,7 @@ as this will always initialize `GOPATH` *unless* it's already initialized (e.g. 
 *You can get the list of available commands by running: `gows --help`,
 and command specific help by running: `gows COMMAND --help`*
 
-* `gows version` : Print the version of `gows`, same as `gows --version`.
+* `gows version` : Print the version of `gows`.
 * `gows init [--reset] [go-package-name]` : Initialize a workspace for the current directory.
   * If called without a go-package-name parameter `gows` will try to determine the package name
     from `git remote` (`git remote get-url origin`).


### PR DESCRIPTION
## Overview

Looks like command name for `version` is wrong in README if my understanding is correct.
Both `gows -version` and `gows --version` give me an error below

`gows version` works fine for me.

```
$ gows version
go version go1.11.4 darwin/amd64
```

## How to reproduce

Run commands below in your terminal

```
$ gows -version
Exit Code was 0, but an error happened: exec: "-version": executable file not found in $PATH
```

```
$ gows --version
Exit Code was 0, but an error happened: exec: "--version": executable file not found in $PATH
```

## Cause

`-h` or `--help` can be detected here, but I guess it's not the same case for `version`?
https://github.com/bitrise-tools/gows/blob/master/cmd/root.go#L91
https://github.com/bitrise-tools/gows/blob/master/cmd/version.go#L12


